### PR TITLE
T12 AI pull request description with gptel

### DIFF
--- a/init.el
+++ b/init.el
@@ -730,8 +730,8 @@ Be terse. Provide messages whose lines are at most 80 characters")
   "Generate a GitHub pull request description by diffing with origin/master.
 
 Upon receiving the response from gptel, it places the generated message
-in a special buffer named *gptel-pull-request* and copies it to the kill
-ring."
+in a special buffer named *gptel-pull-request* and copies it to the
+clipboard and kill ring."
   (interactive)
   (let* ((diff-buffer
           (with-temp-buffer
@@ -753,14 +753,14 @@ ring."
      (lambda (response info)
        (if (not response)
            (message "%s failed with message: %s" who (plist-get info :status))
-         (kill-new response)
          (with-current-buffer (get-buffer-create "*gptel-pull-request*")
            (let ((inhibit-read-only t))
              (erase-buffer)
              (insert response))
            (special-mode)
-           (message "pull request body in kill ring")
-           (pop-to-buffer (current-buffer))))))))
+           (pop-to-buffer (current-buffer))
+           (clipboard+kill-ring-save (point-min) (point-max))
+           (message "pull request body in kill ring")))))))
 
 (defun insert-issue-prefix ()
   (interactive)

--- a/init.el
+++ b/init.el
@@ -727,7 +727,11 @@ Be terse. Provide messages whose lines are at most 80 characters")
            (pop-to-buffer "COMMIT_EDITMSG")))))))
 
 (defun/who gptel-pull-request ()
-  "Generate a GitHub pull request description by diffing with origin/master."
+  "Generate a GitHub pull request description by diffing with origin/master.
+
+Upon receiving the response from gptel, it places the generated message
+in a special buffer named *gptel-pull-request* and copies it to the kill
+ring."
   (interactive)
   (let* ((diff-buffer
           (with-temp-buffer

--- a/init.el
+++ b/init.el
@@ -755,6 +755,7 @@ Be terse. Provide messages whose lines are at most 80 characters")
              (erase-buffer)
              (insert response))
            (special-mode)
+           (message "pull request body in kill ring")
            (pop-to-buffer (current-buffer))))))))
 
 (defun insert-issue-prefix ()

--- a/init.el
+++ b/init.el
@@ -40,6 +40,17 @@
        (dolist (,pkg ,to-install)
          (package-install ,pkg)))))
 
+(defmacro defun/who (name args &rest body)
+  "Define a function NAME with arguments ARGS and body BODY.
+
+Includes the function name as a local variable WHO within the body."
+  `(defun ,name ,args
+     (let ((who ',name))
+       ,@body)))
+
+(unless (get 'defun/who 'lisp-indent-function)
+  (put 'defun/who 'lisp-indent-function 'defun))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Straight.el config
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
## Pull Request Description

### Summary of Changes

1. **New Macro Definition: `defun/who`**
   - Added the `defun/who` macro, which defines a function with an additional `who` local variable inside the body.
   - Supports an optional `:command` keyword to make the function interactive.

2. **Keybinding Addition**
   - Added a new keybinding `C-c M-p` for the newly defined `gptel-pull-request` function within the `gptel` use-package configuration.

3. **New Function: `gptel-pull-request`**
   - Introduced the `gptel-pull-request` function. This function generates a GitHub pull request description by creating a diff with `origin/master`.
   - On invocation, it processes the diff, sends it to `gptel`, and displays the response in a buffer named `*gptel-pull-request*`. The response is also copied to the clipboard and kill ring.

4. **Code Cleanup**
   - Removed an unused variable `tmp` that was defined as `"TEMP2"`.

5. **Enhanced `gptel-diff` Function**
   - Improved readability and formatting of the existing `gptel-diff` function.

### Detailed Additions

#### Macro: `defun/who`

```elisp
(defmacro defun/who (name args &rest body)
  "Define a function NAME with arguments ARGS and body BODY.
Includes the function name as a local variable WHO within the body.
Special keyword arguments:
  :command -- If provided, make the function interactive."
  (let* ((docstring (if (stringp (car body)) (pop body)))
         (options (when (keywordp (car body)) (pop body)))
         (command (progn
                    (message "options was: %s" options)
                    (eq :command options))))
    `(defun ,name ,args
       ,@(when docstring (list docstring))
       ,@(when command '((interactive)))
       (let ((who ',name))
         ,@body))))

(unless (get 'defun/who 'lisp-indent-function)
  (put 'defun/who 'lisp-indent-function 'defun))
```

#### Function: `gptel-pull-request`

```elisp
(defun/who gptel-pull-request ()
  "Generate a GitHub pull request description by diffing with origin/master.
Upon receiving the response from gptel, it places the generated message
in a special buffer named *gptel-pull-request* and copies it to the
clipboard and kill ring."
  :command
  (let* ((diff-buffer
          (with-temp-buffer
            (magit-diff-range "origin/master")
            (buffer-string)))
         (request-string
          (concat
           "Generate a pull request description summarizing the changes:\n\n"
           diff-buffer)))
    (ensure-gptel-directives-loaded)
    (gptel-request/require
     request-string
     :system
     (alist-get
      'PullRequest
      gptel-directives
      "Summarize the changes for a GitHub pull request description.")
     :callback
     (lambda (response info)
       (if (not response)
           (message "%s failed with message: %s" who (plist-get info :status))
         (with-current-buffer (get-buffer-create "*gptel-pull-request*")
           (let ((inhibit-read-only t))
             (erase-buffer)
             (insert response))
           (special-mode)
           (pop-to-buffer (current-buffer))
           (clipboard+kill-ring-save (point-min) (point-max))
           (message "pull request body in kill ring")))))))
```

These changes enhance automation for generating GitHub pull request descriptions and streamline function definitions with added flexibility.
 