### PR TITLE
T20 AI based test case generation

### DIFF
--- a/init.el
+++ b/init.el
@@ -800,9 +800,9 @@ If the PROMPT is empty, signals a user error."
                 (insert *gptel-response*))
               (special-mode)
               (display-buffer (current-buffer)))))
-  :extra-args (list :system
-                    (alist-get 'default gptel-directives
-                               "You are a helpful assistant.")))
+  :extra-args
+  (make-gptel-system-prompt-args 'default "You are a helpful assistant."))
+
 
 (defgptelfn gptel-diff ()
   "Generate a git commit message.
@@ -839,13 +839,11 @@ in the kill ring."
       (message "commit message in kill ring")
       (pop-to-buffer "COMMIT_EDITMSG")))
   :extra-args
-  (list
-   :system
-   (alist-get
-    'commiter
-    gptel-directives
-    "Write a git commit message for this diff. Include ONLY the message.
-Be terse. Provide messages whose lines are at most 80 characters")))
+  (make-gptel-system-prompt-args
+   'commiter
+   "Write a git commit message for this diff. Include ONLY the message.
+Be terse. Provide messages whose lines are at most 80 characters"))
+
 
 (defgptelfn gptel-pull-request ()
   "Generate a GitHub pull request description by diffing with origin/master.
@@ -876,12 +874,10 @@ clipboard and kill ring."
       (clipboard+kill-ring-save (point-min) (point-max))
       (message "pull request body in kill ring")))
   :extra-args
-  (list
-   :system
-   (alist-get
-    'pullrequest
-    gptel-directives
-    "Summarize the changes for a GitHub pull request description.")))
+  (make-gptel-system-prompt-args
+   'pullrequest
+   "Summarize the changes for a GitHub pull request description."))
+
 
 (defvar gptel-document-symbol-at-point--history nil)
 
@@ -946,10 +942,8 @@ History:
       (special-mode)
       (display-buffer (current-buffer))))
   :extra-args
-  (list
-   :system
-   (alist-get 'documentation gptel-directives
-              "Prefer making a docstring")))
+  (make-gptel-system-prompt-args 'documentation "Prefer making a docstring"))
+
 
 (defmacro with-gptel-directives (&rest body)
   "Ensures GPTel directives are loaded before executing BODY.

--- a/init.el
+++ b/init.el
@@ -185,8 +185,8 @@ Returns:
   :ensure t
   :config
   (setq gptel-model "gpt-4o"
-        gptel-api-key (get-openai-api-key)
-        gptel-directives (try-reload-gptel-directives))
+        gptel-api-key (get-openai-api-key))
+  (ensure-gptel-directives-loaded)
   (setq-default
    gptel--system-message
    (alist-get 'default gptel-directives "You are a helpful assistant."))
@@ -679,7 +679,7 @@ gptel-request with ARGS."
 (defvar *llm-prompts-dir* "~/.llm-prompts"
   "Directory containing the PROMPT.md files.")
 
-(defun/who try-reload-gptel-directives ()
+(defun/who reload-gptel-directives ()
   "Try reloading `gptel-directives` from `*llm-prompts-dir*`.
 
 This function attempts to load GPT-3 directives from the files located in the
@@ -701,7 +701,8 @@ Returns:
   valid files, or nil otherwise."
   :command
   (if (file-exists-p *llm-prompts-dir*)
-      (read-prompt-md-files *llm-prompts-dir*)
+      (setq gptel-directives
+            (read-prompt-md-files *llm-prompts-dir*))
     (message "%s: LLM prompts directory %s does not exist!"
              who
              *llm-prompts-dir*)))
@@ -709,8 +710,7 @@ Returns:
 (defun ensure-gptel-directives-loaded ()
   "Ensure that `gptel-directives` is defined."
   (unless (boundp 'gptel-directives)
-    (setq gptel-directives (try-reload-gptel-directives))))
-
+    (reload-gptel-directives)))
 
 (defvar gptel-quick--history nil
   "History list for `gptel-quick' prompts.")

--- a/init.el
+++ b/init.el
@@ -58,6 +58,22 @@ Special keyword arguments:
          ,@body))))
 
 (defun indent-like-defun (sym)
+  "Set the `lisp-indent-function` property of SYM to `defun`.
+
+This function checks whether SYM has the `lisp-indent-function` property set.
+If not, it assigns `defun` as its `lisp-indent-function`, allowing SYM to be
+indented like a standard Emacs `defun`.  This function is typically used for
+macros that define new constructs or syntax that follow the same indentation
+rules as regular function definitions in Lisp languages.
+
+Example usage:
+  (indent-like-defun 'my-custom-macro)
+
+Arguments:
+  SYM -- The symbol to set the `lisp-indent-function` property for.
+
+Returns:
+  nil"
   (unless (get sym 'lisp-indent-function)
     (put sym 'lisp-indent-function 'defun)))
 
@@ -663,7 +679,9 @@ gptel-request with ARGS."
 (defun ensure-gptel-directives-loaded ()
   "Ensure that `gptel-directives` is defined."
   (unless (boundp 'gptel-directives)
-    (setq gptel-directives (or (read-prompt-md-files "~/.llm-prompts") '()))))
+    (setq gptel-directives
+          (when (file-exists-p "~/.llm-prompts")
+                (read-prompt-md-files "~/.llm-prompts")))))
 
 (defvar gptel-quick--history nil
   "History list for `gptel-quick' prompts.")


### PR DESCRIPTION
# Pull Request Description

## Summary of Changes

This pull request introduces several enhancements and refactorings to improve the Lisp indentation functions and GPTel directive handling within the `init.el` file. The key changes are highlighted as follows:

### New Functions and Macros

1. **`indent-like-defun`**
   - Sets the `lisp-indent-function` property of a symbol to `defun` if it is not already set.
   - Example usage: `(indent-like-defun 'my-custom-macro)`

2. **`reload-gptel-directives`**
   - Reloads `gptel-directives` from a specified directory (`*llm-prompts-dir*`).
   - Example usage: `(reload-gptel-directives)`

3. **Macron `with-gptel-directives`**
   - Ensures GPTel directives are loaded before executing a body of code.
   - Example usage: 
     ```elisp
     (with-gptel-directives
       (do-something-with-directives))
     ```

4. **`make-gptel-system-prompt-args`**
   - Generates system prompt arguments for GPTel requests with a fallback for missing directives.
   - Example usage: `(make-gptel-system-prompt-args 'directive-key "Default directive text")`

### Refactoring

1. **`ensure-gptel-directives-loaded`**
   - Simplified to directly use `reload-gptel-directives`.

2. **Macro `defgptelfn`**
   - Added function `gptel-tests-for-symbol-at-point` to generate test cases for a symbol.

### Improved Function Documentation

1. **`dynamic-prompt`**
   - Expanded function documentation to include detailed descriptions, argument explanations, and usage examples.

2. **`gptel-document-symbol-at-point`**
   - Enhanced documentation to be more explicit and user-friendly, maintaining a history of user inputs.

### Minor Enhancements

1. **`read-prompt-md-files`**
   - Added message logging indicating prompts are loaded from the specified directory.

### Bug Fixes and Other Changes

1. **Correctness in `gptel-pull-request` and `gptel-diff` Extra Args**
   - Updated call to generate system prompts using `make-gptel-system-prompt-args`, ensuring directives are correctly loaded.

## Example Usages

- **Indent Like Defun:**
  ```elisp
  (indent-like-defun 'my-custom-macro)
  ```

- **Reload GPTel Directives:**
  ```elisp
  (reload-gptel-directives)
  ```

- **Generate Dynamic Prompt for ChatGPT Queries:**
  ```elisp
  (dynamic-prompt
    (lambda () "What is the weather like?")
    (lambda (response info) (message "Response: %s" response))
    (lambda () '(:system "default system message")))
  ```

- **Generate Test Cases for Symbol at Point:**
  ```elisp
  (gptel-tests-for-symbol-at-point 'example-fun)
  ```

These improvements collectively aim to make the development experience with Lisp and GPTel directives more robust and user-friendly.