### PR TITLE
T10 Fix clipboard+kill-ring-save on linux

### DIFF
--- a/init.el
+++ b/init.el
@@ -594,18 +594,30 @@ that as the default suggestion."
    (shell-command-on-region beg end "pbcopy"))
   (deactivate-mark))
 
+(defun copy-to-clipboard/linux (beg end)
+  "Copy the region from BEG to END to the system clipboard."
+  (interactive "r")
+  (if (use-region-p)
+      (let ((text (buffer-substring-no-properties beg end)))
+        (with-temp-buffer
+          (insert text)
+          (call-process-region
+           (point-min) (point-max)
+           "xclip" nil nil nil "-selection" "clipboard")))
+    (message "No region selected")))
+
+
 (defun clipboard+kill-ring-save (beg end)
   "Copies selection to x-clipboard."
   (interactive "r")
-  (copy-to-clipboard/macos beg end)
+  (syscase
+   (darwin
+    (copy-to-clipboard/macos beg end))
+   (gnu/linux
+    (copy-to-clipboard/linux beg end)))
   (kill-ring-save beg end))
 
 (global-set-key (kbd "M-w") 'clipboard+kill-ring-save)
-
-(global-set-key (kbd "C-x p")
-                (lambda ()
-                  (interactive)
-                  (other-window -1)))
 
 (global-set-key (kbd "C-x p")
                 (lambda ()

--- a/init.el
+++ b/init.el
@@ -37,9 +37,7 @@ Special keyword arguments:
   :command -- If provided, make the function interactive."
   (let* ((docstring (if (stringp (car body)) (pop body)))
          (options (when (keywordp (car body)) (pop body)))
-         (command (progn
-                    (message "options was: %s" options)
-                    (eq :command options))))
+         (command (eq :command options)))
     `(defun ,name ,args
        ,@(when docstring (list docstring))
        ,@(when command '((interactive)))
@@ -590,21 +588,22 @@ that as the default suggestion."
 
 (defun copy-to-clipboard/macos (beg end)
   (interactive "r")
-  (when (eq system-type 'darwin)
-   (shell-command-on-region beg end "pbcopy"))
-  (deactivate-mark))
+  (on-macos
+   (shell-command-on-region beg end "pbcopy")
+   (deactivate-mark)))
 
 (defun copy-to-clipboard/linux (beg end)
   "Copy the region from BEG to END to the system clipboard."
   (interactive "r")
-  (if (use-region-p)
-      (let ((text (buffer-substring-no-properties beg end)))
-        (with-temp-buffer
-          (insert text)
-          (call-process-region
-           (point-min) (point-max)
-           "xclip" nil nil nil "-selection" "clipboard")))
-    (message "No region selected")))
+  (on-linux
+   (if (use-region-p)
+       (let ((text (buffer-substring-no-properties beg end)))
+         (with-temp-buffer
+           (insert text)
+           (call-process-region
+            (point-min) (point-max)
+            "xclip" nil nil nil "-selection" "clipboard")))
+     (message "No region selected"))))
 
 
 (defun clipboard+kill-ring-save (beg end)

--- a/init.el
+++ b/init.el
@@ -800,9 +800,9 @@ If the PROMPT is empty, signals a user error."
                 (insert *gptel-response*))
               (special-mode)
               (display-buffer (current-buffer)))))
-  :extra-args (list :system
-                    (alist-get 'default gptel-directives
-                               "You are a helpful assistant.")))
+  :extra-args
+  (make-gptel-system-prompt-args 'default "You are a helpful assistant."))
+
 
 (defgptelfn gptel-diff ()
   "Generate a git commit message.
@@ -839,13 +839,11 @@ in the kill ring."
       (message "commit message in kill ring")
       (pop-to-buffer "COMMIT_EDITMSG")))
   :extra-args
-  (list
-   :system
-   (alist-get
-    'commiter
-    gptel-directives
-    "Write a git commit message for this diff. Include ONLY the message.
-Be terse. Provide messages whose lines are at most 80 characters")))
+  (make-gptel-system-prompt-args
+   'commiter
+   "Write a git commit message for this diff. Include ONLY the message.
+Be terse. Provide messages whose lines are at most 80 characters"))
+
 
 (defgptelfn gptel-pull-request ()
   "Generate a GitHub pull request description by diffing with origin/master.
@@ -876,12 +874,10 @@ clipboard and kill ring."
       (clipboard+kill-ring-save (point-min) (point-max))
       (message "pull request body in kill ring")))
   :extra-args
-  (list
-   :system
-   (alist-get
-    'pullrequest
-    gptel-directives
-    "Summarize the changes for a GitHub pull request description.")))
+  (make-gptel-system-prompt-args
+   'pullrequest
+   "Summarize the changes for a GitHub pull request description."))
+
 
 (defvar gptel-document-symbol-at-point--history nil)
 
@@ -946,10 +942,8 @@ History:
       (special-mode)
       (display-buffer (current-buffer))))
   :extra-args
-  (list
-   :system
-   (alist-get 'documentation gptel-directives
-              "Prefer making a docstring")))
+  (make-gptel-system-prompt-args 'documentation "Prefer making a docstring"))
+
 
 (defmacro with-gptel-directives (&rest body)
   "Ensures GPTel directives are loaded before executing BODY.

--- a/init.el
+++ b/init.el
@@ -185,8 +185,8 @@ Returns:
   :ensure t
   :config
   (setq gptel-model "gpt-4o"
-        gptel-api-key (get-openai-api-key)
-        gptel-directives (try-reload-gptel-directives))
+        gptel-api-key (get-openai-api-key))
+  (ensure-gptel-directives-loaded)
   (setq-default
    gptel--system-message
    (alist-get 'default gptel-directives "You are a helpful assistant."))
@@ -679,7 +679,7 @@ gptel-request with ARGS."
 (defvar *llm-prompts-dir* "~/.llm-prompts"
   "Directory containing the PROMPT.md files.")
 
-(defun/who try-reload-gptel-directives ()
+(defun/who reload-gptel-directives ()
   "Try reloading `gptel-directives` from `*llm-prompts-dir*`.
 
 This function attempts to load GPT-3 directives from the files located in the
@@ -701,7 +701,8 @@ Returns:
   valid files, or nil otherwise."
   :command
   (if (file-exists-p *llm-prompts-dir*)
-      (read-prompt-md-files *llm-prompts-dir*)
+      (setq gptel-directives
+            (read-prompt-md-files *llm-prompts-dir*))
     (message "%s: LLM prompts directory %s does not exist!"
              who
              *llm-prompts-dir*)))
@@ -709,8 +710,7 @@ Returns:
 (defun ensure-gptel-directives-loaded ()
   "Ensure that `gptel-directives` is defined."
   (unless (boundp 'gptel-directives)
-    (setq gptel-directives (try-reload-gptel-directives))))
-
+    (reload-gptel-directives)))
 
 (defvar gptel-quick--history nil
   "History list for `gptel-quick' prompts.")

--- a/init.el
+++ b/init.el
@@ -111,7 +111,7 @@ signaling an error if it isn't."
          (progn ,y ,@rest))))))
 
 (defmacro syscase (&rest clauses)
-  "Macro that conditionally evaluates forms based on the system type.
+  "Conditionally evaluate forms based on the system type.
 
 CLAUSES should be a list of forms, where each form is structured as:
     (SYSTEM-TYPE BODY...)

--- a/init.el
+++ b/init.el
@@ -58,6 +58,22 @@ Special keyword arguments:
          ,@body))))
 
 (defun indent-like-defun (sym)
+  "Set the `lisp-indent-function` property of SYM to `defun`.
+
+This function checks whether SYM has the `lisp-indent-function` property set.
+If not, it assigns `defun` as its `lisp-indent-function`, allowing SYM to be
+indented like a standard Emacs `defun`.  This function is typically used for
+macros that define new constructs or syntax that follow the same indentation
+rules as regular function definitions in Lisp languages.
+
+Example usage:
+  (indent-like-defun 'my-custom-macro)
+
+Arguments:
+  SYM -- The symbol to set the `lisp-indent-function` property for.
+
+Returns:
+  nil"
   (unless (get sym 'lisp-indent-function)
     (put sym 'lisp-indent-function 'defun)))
 
@@ -663,7 +679,9 @@ gptel-request with ARGS."
 (defun ensure-gptel-directives-loaded ()
   "Ensure that `gptel-directives` is defined."
   (unless (boundp 'gptel-directives)
-    (setq gptel-directives (or (read-prompt-md-files "~/.llm-prompts") '()))))
+    (setq gptel-directives
+          (when (file-exists-p "~/.llm-prompts")
+                (read-prompt-md-files "~/.llm-prompts")))))
 
 (defvar gptel-quick--history nil
   "History list for `gptel-quick' prompts.")


### PR DESCRIPTION
# Pull Request Description

## Summary

This pull request introduces several significant changes and improvements to the `init.el` configuration file. These changes include the removal of redundant macros, the introduction of new macros for OS-specific operations, enhancements to clipboard handling functions, and general code cleanup.

## Changes

1. **Removed Macros**:
   - `on-system`, `on-macos`, and `on-linux` macros were removed.

2. **New Macros and Functions**:
   - Introduced a new macro `syscase` for conditional evaluation based on the system type.
   - Introduced a helper function `expand-syscond-clause` to support `syscase`.
   - Reintroduced `on-macos` and `on-linux` macros using the `syscase` macro.

3. **Clipboard Handling Improvements**:
   - Updated `copy-to-clipboard/macos` to use the new `on-macos` macro.
   - Added `copy-to-clipboard/linux` for GNU/Linux systems.
   - Enhanced `clipboard+kill-ring-save` to conditionally handle clipboard operations based on the system type using `syscase`.

4. **Code Cleanup**:
   - Removed redundant debug message in an existing macro expansion.
   - General formatting and indentation improvements for better readability.

## Detailed Changes

- **Removed Existing Macros**:
  ```elisp
  (defmacro on-system (system &rest body)
  (defmacro on-macos (&rest body)
  (defmacro on-linux (&rest body)
  ```

- **New Macro and Functions**:
  ```elisp
  (defmacro syscase (&rest clauses)
  (defun/who expand-syscond-clause (clause)
  ```

- **Updated Macros for OS Conditional Execution**:
  ```elisp
  (defmacro on-macos (&rest body)
  (defmacro on-linux (&rest body)
  ```

- **Clipboard Handling Updates**:
  ```elisp
  (defun copy-to-clipboard/macos (beg end)
  (defun/who xclip-buffer (selection-type)
  (defun copy-to-clipboard/linux (beg end)
  (defun clipboard+kill-ring-save (beg end)
  ```

- **Removed Redundant Global Key Binding**:
  ```elisp
  (global-set-key (kbd "C-x p")
  ```

## Impact

- The new `syscase` macro simplifies and centralizes system-specific conditional evaluations.
- Improved clipboard handling functions now support both macOS and GNU/Linux without redundant code.
- Overall codebase readability and maintainability have been enhanced.

This pull request addresses various inefficiencies by removing deprecated macros, refining clipboard operations, and improving the overall structure and readability of the configuration file. These changes ensure a more maintainable and extensible setup moving forward.